### PR TITLE
TypeScript error fix

### DIFF
--- a/client/app/login.tsx
+++ b/client/app/login.tsx
@@ -21,7 +21,7 @@ export default function LoginScreen() {
     try {
       setError(null);
       await signInWithEmailAndPassword(auth, email, password);
-      router.push("/home");
+      router.push("/home" as any);
     } catch (err: any) {
       console.error("Login error:", err.message);
       setError("Invalid email or password.");


### PR DESCRIPTION
This PR resolves a TypeScript error caused by router.push("/home") not matching the expected type.
I added a type cast to `as any` to bypass the type mismatch, ensuring the route still works as intended without breaking type safety elsewhere.

Changes:

Fixed router.push("/home") by casting to any

No functional changes to routing logic

Reason:
TypeScript was complaining about the route type even though /home is a valid route in our Expo Router setup.