### PR TITLE
Integrate recalls endpoint with scanner and update router from GET to POST

### DIFF
--- a/server/src/routes/scanner.routes.ts
+++ b/server/src/routes/scanner.routes.ts
@@ -2,6 +2,6 @@ import { Router } from "express";
 import { getRecalls } from "../controllers/scanner.controller";
 
 const router = Router();
-router.get("/recalls", getRecalls);
+router.post("/recalls", getRecalls);
 
 export default router;


### PR DESCRIPTION
This PR integrates the recalls backend API endpoint with the scanner screen in the frontend, enabling receipt scans to fetch recall data dynamically.

Additionally, it updates the backend router method from `GET` to `POST` for the `/api/scanner/recalls` endpoint to properly handle receipt image uploads.

Future improvements include switching from `fetch` to `axios` for API calls after further testing.

Please review the integration carefully to ensure everything works smoothly.