### PR TITLE
Add app name and remove unused "Forgot Password" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Recall Scanner
+# Scantra
 
 A mobile application that helps users identify potentially recalled products from their store receipts.
 
 ## Overview
 
-Recall Scanner allows users to scan their store receipts (paper or email) and automatically checks the products and companies against FDA recall data. If a match is found, users receive an instant alert with color-coded urgency:
+Scantra allows users to scan their store receipts (paper or email) and automatically checks the products and companies against FDA recall data. If a match is found, users receive an instant alert with color-coded urgency:
 
 - 🟡 **Company recall** - The company has issued some recalls
 - 🟠 **Related Product flagged** - Similar products from this company have been recalled

--- a/client/app/index.tsx
+++ b/client/app/index.tsx
@@ -10,7 +10,7 @@ export default function Index() {
     <View style={styles.welcomePage}>
       <View style={styles.welcomePage__header}>
         <Ionicons name="scan-circle-outline" size={120} color="#4E148C" />
-        <Text style={styles.welcomePage__title}>Recall Scanner</Text>
+        <Text style={styles.welcomePage__title}>Scantra</Text>
         <Text style={styles.welcomePage__subtitle}>
           Protect your family from recalled products
         </Text>

--- a/client/app/login.tsx
+++ b/client/app/login.tsx
@@ -75,8 +75,6 @@ export default function LoginScreen() {
         />
       </View>
 
-      <Text style={styles.login__forgot}>Forgot Password?</Text>
-
       <TouchableOpacity
         style={[styles.login__loginBtn, loading && { opacity: 0.7 }]}
         onPress={handleLogin}

--- a/client/app/tabs/home.tsx
+++ b/client/app/tabs/home.tsx
@@ -12,7 +12,7 @@ export default function HomeScreen() {
   return (
     <View style={styles.home}>
       <View style={styles.home__header}>
-        <Text style={styles.home__title}>Welcome to Recall Scanner</Text>
+        <Text style={styles.home__title}>Welcome to Scantra</Text>
         <Text style={styles.home__subtitle}>
           Keep your family safe from recalled products
         </Text>


### PR DESCRIPTION
This update includes two main changes:

App Name:
Introduced the official name of the application in the designated area.

Removed "Forgot Password?" Feature:
Since password recovery isn't required for this version, the "Forgot Password?" link and related logic have been removed to simplify the authentication flow.

These changes help streamline the user experience and reflect the current scope of the app